### PR TITLE
Fixing empty links

### DIFF
--- a/admob/testapp/readme.md
+++ b/admob/testapp/readme.md
@@ -37,7 +37,7 @@ Getting Started
       - You can use "com.google.ios.admob.testapp" as the iOS Bundle ID
         while you're testing. You can omit App Store ID while testing.
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -88,7 +88,7 @@ Getting Started
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -118,7 +118,7 @@ Getting Started
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/analytics/testapp/readme.md
+++ b/analytics/testapp/readme.md
@@ -39,7 +39,7 @@ Building and Running the testapp
       console to the testapp root directory. This file identifies your iOS app
       to the Firebase backend.
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -62,7 +62,7 @@ Building and Running the testapp
     "View --> Debug Area --> Activate Console" from the menu.
   - After 5 hours, data should be visible in the Firebase Console under the
     "Analytics" tab accessible from
-    [https://firebase.google.com/console/]().
+    https://firebase.google.com/console/.
 
 ### Android
   - Register your Android app with Firebase.
@@ -90,7 +90,7 @@ Building and Running the testapp
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -112,12 +112,12 @@ Building and Running the testapp
     the command line.
   - After 5 hours, data should be visible in the Firebase Console under the
     "Analytics" tab accessible from
-    [https://firebase.google.com/console/]().
+    https://firebase.google.com/console/.
 
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/auth/testapp/readme.md
+++ b/auth/testapp/readme.md
@@ -58,7 +58,7 @@ Building and Running the testapp
       enable "Anonymous". This will allow the testapp to use email accounts and
       anonymous sign-in.
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -110,7 +110,7 @@ Building and Running the testapp
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -162,7 +162,7 @@ Known issues
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/database/testapp/readme.md
+++ b/database/testapp/readme.md
@@ -70,7 +70,7 @@ Building and Running the testapp
       authenticate with Firebase Database, which requires a signed-in user by
       default (an anonymous user will suffice).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -125,7 +125,7 @@ Building and Running the testapp
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -159,7 +159,7 @@ Known issues
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/invites/testapp/readme.md
+++ b/invites/testapp/readme.md
@@ -48,7 +48,7 @@ Building and Running the testapp
       YOUR\_REVERSED\_CLIENT\_ID. Replace this with the value of the
       REVERSED\_CLIENT\_ID string in GoogleService-Info.plist.
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -108,7 +108,7 @@ Building and Running the testapp
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -152,7 +152,7 @@ Building and Running the testapp
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/messaging/testapp/readme.md
+++ b/messaging/testapp/readme.md
@@ -45,7 +45,7 @@ Building and Running the testapp
       console to the testapp root directory. This file identifies your iOS app
       to the Firebase backend.
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -105,7 +105,7 @@ with:
 [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
 
 - Download the Firebase C++ SDK linked from
-  [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+  https://firebase.google.com/docs/cpp/setup and unzip it to a
   directory of your choice.
 
 **Configure your SDK paths**
@@ -161,7 +161,7 @@ curl --header "Authorization: key=<Server Key>" --header "Content-Type: applicat
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/remote_config/testapp/readme.md
+++ b/remote_config/testapp/readme.md
@@ -41,7 +41,7 @@ Building and Running the testapp
       console to the testapp root directory. This file identifies your iOS app
       to the Firebase backend.
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -89,7 +89,7 @@ Building and Running the testapp
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -127,7 +127,7 @@ keys that begin with "TestD".
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------

--- a/storage/testapp/readme.md
+++ b/storage/testapp/readme.md
@@ -63,7 +63,7 @@ Building and Running the testapp
       authenticate with Firebase Storage, which requires a signed-in user by
       default (an anonymous user will suffice).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Add the following frameworks from the Firebase C++ SDK to the project:
     - frameworks/ios/universal/firebase.framework
@@ -118,7 +118,7 @@ Building and Running the testapp
     - For further details please refer to the
       [general instructions for setting up an Android app with Firebase](https://firebase.google.com/docs/android/setup).
   - Download the Firebase C++ SDK linked from
-    [https://firebase.google.com/docs/cpp/setup]() and unzip it to a
+    https://firebase.google.com/docs/cpp/setup and unzip it to a
     directory of your choice.
   - Configure the location of the Firebase C++ SDK by setting the
     firebase\_cpp\_sdk.dir Gradle property to the SDK install directory.
@@ -142,7 +142,7 @@ Building and Running the testapp
 Support
 -------
 
-[https://firebase.google.com/support/]()
+https://firebase.google.com/support/
 
 License
 -------


### PR DESCRIPTION
In GitHub markdown a link of the form `[.*]()` will just link back to the current page.  The intended usage of the links were to to go to themselves, which GitHub does for you when a URL appears in normal Markdown text.