### PR TITLE
Workarounds to make the RTDB testapp work with latest Android Studio.

### DIFF
--- a/database/testapp/AndroidManifest.xml
+++ b/database/testapp/AndroidManifest.xml
@@ -6,7 +6,6 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="24" />
   <application android:label="@string/app_name">
     <activity android:name="android.app.NativeActivity"
               android:screenOrientation="portrait"

--- a/database/testapp/CMakeLists.txt
+++ b/database/testapp/CMakeLists.txt
@@ -118,6 +118,8 @@ else()
   endif()
 endif()
 
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,libfirebase_database.a -Wl,--exclude-libs,libfirebase_auth.a -Wl,--exclude-libs,libfirebase_app.a")
+
 # Add the Firebase libraries to the target using the function from the SDK.
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 # Note that firebase_app needs to be last in the list.

--- a/database/testapp/build.gradle
+++ b/database/testapp/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 26
+  compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
   sourceSets {


### PR DESCRIPTION
Using Android Studio 3.4.2 and Pixel 2 XL (Android 9, API 28) emulator,
trying to compile the testapp produces the following errors:
* `ERROR: The minSdk version should not be declared in the android
manifest file. You can move the version from the manifest to the
defaultConfig in the build.gradle file.` Solution/workaround: just
remove the element from the XML file;
* `error: resource android:attr/fontVariationSettings
not found` and `error: resource android:attr/ttcIndex not found`.
Solution/workaround: increase `compileSdkVersion` in `build.gradle`
to `28` (taken from here:
https://stackoverflow.com/questions/51291407/androidx-modules-androidattr-ttcindex-androidattr-fontvariationsettings-not/51291698);
* many errors like:
```
libfirebase_database.a(data_snapshot.o): relocation R_386_GOTOFF
against preemptible symbol
_ZN8firebase8database9CleanupFnINS0_12DataSnapshotENS0_8internal20DataSnapshotInternalEE21create_invalid_objectE
cannot be used when making a shared object
```
Solution/workaround: add the following to `CMakeLists.txt`:
```
set(CMAKE_SHARED_LINKER_FLAGS
    "${CMAKE_SHARED_LINKER_FLAGS}
    -Wl,--exclude-libs,libfirebase_database.a
    -Wl,--exclude-libs,libfirebase_auth.a
    -Wl,--exclude-libs,libfirebase_app.a")
```
(taken from here:
 https://github.com/opencv/opencv/issues/10229#issuecomment-359202825)