### PR TITLE
Update Firestore example for API changes

### DIFF
--- a/firestore/testapp/src/common_main.cc
+++ b/firestore/testapp/src/common_main.cc
@@ -65,7 +65,7 @@ class TestEventListener : public Countable,
   void OnEvent(const T& value,
                const firebase::firestore::Error error) override {
     event_count_++;
-    if (error != firebase::firestore::Ok) {
+    if (error != firebase::firestore::kOk) {
       LogMessage("ERROR: EventListener %s got %d.", name_.c_str(), error);
     }
   }
@@ -170,7 +170,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
   LogMessage("Successfully initialized Firebase Firestore.");
 
-  firestore->set_logging_enabled(true);
+  firestore->set_log_level(firebase::LogLevel::kLogLevelVerbose);
 
   if (firestore->app() != app) {
     LogMessage("ERROR: failed to get App the Firestore was created with.");
@@ -219,28 +219,28 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
 
   LogMessage("Testing Set().");
-  document.Set(firebase::firestore::MapFieldValue{
-      {"str", firebase::firestore::FieldValue::FromString("foo")},
-      {"int", firebase::firestore::FieldValue::FromInteger(123LL)}});
-  Await(document.SetLastResult(), "document.Set");
-  if (document.SetLastResult().status() != firebase::kFutureStatusComplete) {
+  auto setResult=document.Set(firebase::firestore::MapFieldValue{
+      {"str", firebase::firestore::FieldValue::String("foo")},
+      {"int", firebase::firestore::FieldValue::Integer(123LL)}});
+  Await(setResult, "document.Set");
+  if (setResult.status() != firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to write document.");
   }
 
   LogMessage("Testing Update().");
-  document.Update(firebase::firestore::MapFieldValue{
-      {"int", firebase::firestore::FieldValue::FromInteger(321LL)}});
-  Await(document.UpdateLastResult(), "document.Update");
-  if (document.UpdateLastResult().status() != firebase::kFutureStatusComplete) {
+  auto updateResult=document.Update(firebase::firestore::MapFieldValue{
+      {"int", firebase::firestore::FieldValue::Integer(321LL)}});
+  Await(updateResult, "document.Update");
+  if (updateResult.status() != firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to write document.");
   }
 
   LogMessage("Testing Get().");
-  document.Get();
-  Await(document.GetLastResult(), "document.Get");
-  if (document.GetLastResult().status() == firebase::kFutureStatusComplete) {
+  auto getDocumentResult=document.Get();
+  Await(getDocumentResult, "document.Get");
+  if (getDocumentResult.status() == firebase::kFutureStatusComplete) {
     const firebase::firestore::DocumentSnapshot* snapshot =
-        document.GetLastResult().result();
+        getDocumentResult.result();
     if (snapshot == nullptr) {
       LogMessage("ERROR: failed to read document.");
     } else {
@@ -263,9 +263,9 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
 
   LogMessage("Testing Delete().");
-  document.Delete();
-  Await(document.DeleteLastResult(), "document.Delete");
-  if (document.DeleteLastResult().status() != firebase::kFutureStatusComplete) {
+  auto deleteResult=document.Delete();
+  Await(deleteResult, "document.Delete");
+  if (deleteResult.status() != firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to delete document.");
   }
   LogMessage("Tested document operations.");
@@ -282,34 +282,34 @@ extern "C" int common_main(int argc, const char* argv[]) {
   firebase::firestore::WriteBatch batch = firestore->batch();
   batch.Set(collection.Document("one"),
             firebase::firestore::MapFieldValue{
-                {"str", firebase::firestore::FieldValue::FromString("foo")}});
+                {"str", firebase::firestore::FieldValue::String("foo")}});
   batch.Set(collection.Document("two"),
             firebase::firestore::MapFieldValue{
-                {"int", firebase::firestore::FieldValue::FromInteger(123LL)}});
-  batch.Commit();
-  Await(batch.CommitLastResult(), "batch.Commit");
-  if (batch.CommitLastResult().status() != firebase::kFutureStatusComplete) {
+                {"int", firebase::firestore::FieldValue::Integer(123LL)}});
+  auto commitResult=batch.Commit();
+  Await(commitResult, "batch.Commit");
+  if (commitResult.status() != firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to write batch.");
   }
   LogMessage("Tested batch write.");
 
   LogMessage("Testing transaction.");
-  firestore->RunTransaction(
-      [collection](firebase::firestore::Transaction* transaction,
-                   std::string* error_message) -> firebase::firestore::Error {
-        transaction->Update(
+  auto runTransactionResult=firestore->RunTransaction(
+      [collection](firebase::firestore::Transaction& transaction,
+                   std::string& error_message) -> firebase::firestore::Error {
+        transaction.Update(
             collection.Document("one"),
             firebase::firestore::MapFieldValue{
-                {"int", firebase::firestore::FieldValue::FromInteger(123LL)}});
-        transaction->Delete(collection.Document("two"));
-        transaction->Set(
+                {"int", firebase::firestore::FieldValue::Integer(123LL)}});
+        transaction.Delete(collection.Document("two"));
+        transaction.Set(
             collection.Document("three"),
             firebase::firestore::MapFieldValue{
-                {"int", firebase::firestore::FieldValue::FromInteger(321LL)}});
-        return firebase::firestore::Ok;
+                {"int", firebase::firestore::FieldValue::Integer(321LL)}});
+        return firebase::firestore::kOk;
       });
-  Await(firestore->RunTransactionLastResult(), "firestore.RunTransaction");
-  if (firestore->RunTransactionLastResult().status() !=
+  Await(runTransactionResult, "firestore.RunTransaction");
+  if (runTransactionResult.status() !=
       firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to run transaction.");
   }
@@ -319,13 +319,13 @@ extern "C" int common_main(int argc, const char* argv[]) {
   firebase::firestore::Query query =
       collection
           .WhereGreaterThan("int",
-                            firebase::firestore::FieldValue::FromBoolean(true))
+                            firebase::firestore::FieldValue::Boolean(true))
           .Limit(3);
-  query.Get();
-  Await(query.GetLastResult(), "query.Get");
-  if (query.GetLastResult().status() == firebase::kFutureStatusComplete) {
+  auto getQueryResult=query.Get();
+  Await(getQueryResult, "query.Get");
+  if (getQueryResult.status() == firebase::kFutureStatusComplete) {
     const firebase::firestore::QuerySnapshot* snapshot =
-        query.GetLastResult().result();
+        getQueryResult.result();
     if (snapshot == nullptr) {
       LogMessage("ERROR: failed to fetch query result.");
     } else {

--- a/firestore/testapp/src/common_main.cc
+++ b/firestore/testapp/src/common_main.cc
@@ -170,7 +170,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
   LogMessage("Successfully initialized Firebase Firestore.");
 
-  firestore->set_log_level(firebase::LogLevel::kLogLevelVerbose);
+  firestore->set_log_level(firebase::LogLevel::kLogLevelWarning);
 
   if (firestore->app() != app) {
     LogMessage("ERROR: failed to get App the Firestore was created with.");

--- a/firestore/testapp/src/common_main.cc
+++ b/firestore/testapp/src/common_main.cc
@@ -219,7 +219,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
 
   LogMessage("Testing Set().");
-  auto setResult=document.Set(firebase::firestore::MapFieldValue{
+  auto setResult = document.Set(firebase::firestore::MapFieldValue{
       {"str", firebase::firestore::FieldValue::String("foo")},
       {"int", firebase::firestore::FieldValue::Integer(123LL)}});
   Await(setResult, "document.Set");
@@ -228,7 +228,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
 
   LogMessage("Testing Update().");
-  auto updateResult=document.Update(firebase::firestore::MapFieldValue{
+  auto updateResult = document.Update(firebase::firestore::MapFieldValue{
       {"int", firebase::firestore::FieldValue::Integer(321LL)}});
   Await(updateResult, "document.Update");
   if (updateResult.status() != firebase::kFutureStatusComplete) {
@@ -236,7 +236,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
 
   LogMessage("Testing Get().");
-  auto getDocumentResult=document.Get();
+  auto getDocumentResult = document.Get();
   Await(getDocumentResult, "document.Get");
   if (getDocumentResult.status() == firebase::kFutureStatusComplete) {
     const firebase::firestore::DocumentSnapshot* snapshot =
@@ -263,7 +263,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   }
 
   LogMessage("Testing Delete().");
-  auto deleteResult=document.Delete();
+  auto deleteResult = document.Delete();
   Await(deleteResult, "document.Delete");
   if (deleteResult.status() != firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to delete document.");
@@ -286,7 +286,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   batch.Set(collection.Document("two"),
             firebase::firestore::MapFieldValue{
                 {"int", firebase::firestore::FieldValue::Integer(123LL)}});
-  auto commitResult=batch.Commit();
+  auto commitResult = batch.Commit();
   Await(commitResult, "batch.Commit");
   if (commitResult.status() != firebase::kFutureStatusComplete) {
     LogMessage("ERROR: failed to write batch.");
@@ -294,7 +294,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
   LogMessage("Tested batch write.");
 
   LogMessage("Testing transaction.");
-  auto runTransactionResult=firestore->RunTransaction(
+  auto runTransactionResult = firestore->RunTransaction(
       [collection](firebase::firestore::Transaction& transaction,
                    std::string& error_message) -> firebase::firestore::Error {
         transaction.Update(
@@ -321,7 +321,7 @@ extern "C" int common_main(int argc, const char* argv[]) {
           .WhereGreaterThan("int",
                             firebase::firestore::FieldValue::Boolean(true))
           .Limit(3);
-  auto getQueryResult=query.Get();
+  auto getQueryResult = query.Get();
   Await(getQueryResult, "query.Get");
   if (getQueryResult.status() == firebase::kFutureStatusComplete) {
     const firebase::firestore::QuerySnapshot* snapshot =


### PR DESCRIPTION
The Firestore example no longer compiles with the latest Firebase (tested with v6.15.0).  Presumably other examples are broken too but I haven't looked at those.

* Enumerations are now prefixed with "k".
* `set_logging_enabled` no longer exists, so I replaced with `set_log_level(kLogLevelVerbose)`.
* `FieldValue::From...` static creation functions seem to have "From" removed from the name.
* There are no longer `...LastResult` methods, so I replaced with `auto` variables.

This was tested on desktop.  It now compiles, but running it is either hanging or it takes ages to run (longer than 30 minutes).  I only cloned the repository to debug a hang in my own code, so I don't know if this is an issue with the Firebase libraries or the example.  I'd be surprised if it's as a result of the changes I made.