### PR TITLE
adding noop workflow to main.

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,14 @@
+name: Desktop builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      apis:
+        description: 'CSV of apis whose quickstart examples we should build'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: noop
+        run: true


### PR DESCRIPTION
Only if you have a workflow in main, can you trigger it manually via the Github UI.
Pushing a dummy workflow so that we can develop in other feature branches and test things
by manually activating the workflows.