### PR TITLE
Update Android build config and source fixes

### DIFF
--- a/admob/testapp/build.gradle
+++ b/admob/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -36,7 +36,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.admob.testapp'
-    minSdkVersion 16
+    minSdkVersion 26
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/admob/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/admob/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/analytics/testapp/build.gradle
+++ b/analytics/testapp/build.gradle
@@ -22,6 +22,10 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.analytics.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/analytics/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/analytics/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/analytics/testapp/src/common_main.cc
+++ b/analytics/testapp/src/common_main.cc
@@ -63,9 +63,9 @@ extern "C" int common_main(int argc, const char* argv[]) {
   // Set the user ID.
   analytics::SetUserId("uber_user_510");
 
-  LogMessage("Set current screen.");
-  // Set the user's current screen.
-  analytics::SetCurrentScreen("Firebase Analytics C++ testapp", "testapp");
+  LogMessage("Log current screen.");
+  // Log the user's current screen.
+  analytics::LogEvent(analytics::kEventScreenView, "Firebase Analytics C++ testapp", "testapp" );
 
   // Log an event with no parameters.
   LogMessage("Log login event.");

--- a/auth/testapp/build.gradle
+++ b/auth/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,6 +22,11 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
+
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +41,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.auth.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/auth/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/auth/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/database/testapp/.idea/modules/testapp.iml
+++ b/database/testapp/.idea/modules/testapp.iml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":" />
+        <option name="LAST_SUCCESSFUL_SYNC_AGP_VERSION" />
+        <option name="LAST_KNOWN_AGP_VERSION" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/../.." />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/database/testapp/build.gradle
+++ b/database/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,6 +22,10 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.database.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/database/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/database/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/dynamic_links/testapp/build.gradle
+++ b/dynamic_links/testapp/build.gradle
@@ -22,6 +22,10 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.dynamiclinks.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/dynamic_links/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/dynamic_links/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/firestore/testapp/build.gradle
+++ b/firestore/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,8 +22,12 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 29
-  buildToolsVersion "29.0.0"
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
+  compileSdkVersion 28
+  buildToolsVersion "28.0.3"
 
   sourceSets {
     main {
@@ -36,8 +40,8 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.firestore.testapp'
-    minSdkVersion 16
-    targetSdkVersion 29
+    minSdkVersion 19
+    targetSdkVersion 28
     versionCode 1
     versionName '1.0'
     externalNativeBuild.cmake {

--- a/firestore/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/firestore/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/functions/testapp/build.gradle
+++ b/functions/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,6 +22,10 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.functions.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/functions/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/functions/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/messaging/testapp/build.gradle
+++ b/messaging/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,15 +22,12 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
-
-  android {
-      compileOptions {
-          sourceCompatibility 1.8
-          targetCompatibility 1.8
-      }
-  }
 
   sourceSets {
     main {
@@ -43,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.messaging.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/messaging/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/messaging/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/remote_config/testapp/build.gradle
+++ b/remote_config/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,6 +22,10 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.remoteconfig.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/remote_config/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/remote_config/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/storage/testapp/build.gradle
+++ b/storage/testapp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.2.1'
+    classpath 'com.android.tools.build:gradle:3.3.3'
     classpath 'com.google.gms:google-services:4.0.1'
   }
 }
@@ -22,6 +22,10 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
@@ -36,7 +40,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.storage.testapp'
-    minSdkVersion 16
+    minSdkVersion 19
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'

--- a/storage/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/storage/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
A pass of the android build process to ensure the testapps can build prior to adding CI to the repo.

Changes include:

- Updates to the repo to realign Android build configuration with internal library dependencies.
    - build.gradle configuration changes
    - gradle.wrapper version bump to 5.6.4

- Updates to test sources.
    - Remote Config - migrate to the new instance-based API.
    - Analytics - migrate to the new method for tracking ScreenViews.

