### PR TITLE
chore: update actions cache to v4 as v2 is a deprecated version 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Cache NDK
         id: cache_ndk
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/android-ndk-r21e
           key: android-ndk-${{ matrix.os }}-r21e
@@ -146,7 +146,7 @@ jobs:
 
       - name: Cache ccache files
         id: cache_ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ccache_dir
           key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -63,7 +63,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -74,14 +74,14 @@ jobs:
           echo "GHA_INSTALL_CCACHE=1" >> $GITHUB_ENV
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
           architecture: ${{ matrix.architecture }}
 
       - name: Add msbuild to PATH
         if: startsWith(matrix.os, 'windows')
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v2
 
       - name: Cache NDK
         id: cache_ndk
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: Update homebrew (avoid bintray errors)
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         if: startsWith(matrix.os, 'macos')
         with:
           timeout_minutes: 10
@@ -114,7 +114,7 @@ jobs:
             brew update
 
       - name: Install prerequisites
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [macos-12, ubuntu-latest, windows-latest]
         architecture: [x64]
-        python_version: [3.7]
+        python_version: [3.9]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -177,7 +177,7 @@ jobs:
           fi
 
       - name: Upload Android integration tests artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: testapps-android-${{ matrix.os }}
@@ -185,19 +185,20 @@ jobs:
           retention-days: ${{ env.artifactRetentionDays }}
 
       - name: Upload Android build results artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: log-artifact
+          name: log-artifact-${{ matrix.os }}
           path: build-results-android-${{ matrix.os }}*
           retention-days: ${{ env.artifactRetentionDays }}
 
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: test_results
-          name: log-artifact
+          pattern: log-artifact-*
+          merge-multiple: true
 
       - name: Summarize build results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
chore: update actions cache to v4 as v2 is a deprecated version

Can't merge new code as build fails on this actions step